### PR TITLE
redesign `ReadableCustomIO`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 The project has an alpha version published to `npm` and basic video and audio demultiplexing, transcoding and multiplexing are functional.
 
-You should be aware that `ffmpeg` is a low-level C API and it is very unsafe to use - trying to interpret 720p as 1080p will always end up with a segfault. `avcpp` adds a semi-safe layer on top of it, but mismatching stream parameters will still lead to a segfault. `ffmpeg` should never segfault if all the parameters are correctly checked and set up - but may easily segfault if these are mismatched - or if the asynchronous methods are reentered.
+You should be aware that `ffmpeg` is a low-level C API and it is very unsafe to use - trying to interpret 720p as 1080p will always end up with a segfault. `avcpp` adds a semi-safe layer on top of it, but mismatching stream parameters will still lead to a segfault. These bindings should never segfault if all the parameters are correctly checked and set up - but may easily segfault if these are mismatched - or if the asynchronous methods are reentered.
 
 Producing a completely safe wrapper that never segfaults, no matter what the user does, is a gargantuan task that is currently not planned.
 
-The current goal is to simply be able to guarantee that a ***correct*** JavaScript code will never segfault on any input file.
+The current goal is to simply be able to guarantee that a ***correct*** JavaScript code will never segfault on any input file. The recommended way to use `ffmpeg` is through the higher level streams API which hides most of the complexity and the various low-level pitfalls of the native `ffmpeg` API.
 
 ## Performance
 

--- a/src/binding/avcpp-readable.cc
+++ b/src/binding/avcpp-readable.cc
@@ -124,8 +124,8 @@ void ReadableCustomIO::PushPendingData(uv_async_t *async) {
       }
       if (self->flowing) {
         verbose("ReadableCustomIO: EOF, stop flowing\n");
+        uv_unref(reinterpret_cast<uv_handle_t *>(self->push_callback));
         self->flowing = false;
-        self->Unref();
       }
       return;
     }
@@ -147,8 +147,8 @@ void ReadableCustomIO::PushPendingData(uv_async_t *async) {
   } while (!self->queue.empty() && more.ToBoolean().Value());
   if (more.ToBoolean().Value() == false) {
     verbose("ReadableCustomIO: pipe is full, stop flowing\n");
+    uv_unref(reinterpret_cast<uv_handle_t *>(self->push_callback));
     self->flowing = false;
-    self->Unref();
   }
   lk.unlock();
   // Unblock write if it is waiting because it has reached the high water mark
@@ -171,8 +171,8 @@ void ReadableCustomIO::_Read(const Napi::CallbackInfo &info) {
   }
 
   verbose("ReadableCustomIO: start flowing\n");
+  uv_ref(reinterpret_cast<uv_handle_t *>(push_callback));
   flowing = true;
-  Ref();
   uv_async_send(push_callback);
 }
 

--- a/src/binding/avcpp-readable.cc
+++ b/src/binding/avcpp-readable.cc
@@ -3,7 +3,8 @@
 #include <exception>
 
 ReadableCustomIO::ReadableCustomIO(const Napi::CallbackInfo &info)
-    : av::CustomIO(), Napi::ObjectWrap<ReadableCustomIO>(info), queue_size(0), eof(false), final_callback() {
+    : av::CustomIO{}, Napi::ObjectWrap<ReadableCustomIO>{info}, queue_size{0}, eof{false},
+      async_context{info.Env(), "ffmpeg_Readable_IO"}, flowing{false}, final_callback{} {
   Napi::Env env{info.Env()};
 
   instance_data = env.GetInstanceData<Nobind::EnvInstanceData<ffmpegInstanceData>>();
@@ -11,15 +12,28 @@ ReadableCustomIO::ReadableCustomIO(const Napi::CallbackInfo &info)
     throw Napi::Error::New(env, "ReadableCustomIO is not initalized");
 
   instance_data->js_Readable_ctor.Call(this->Value(), {});
+
+  uv_loop_t *event_loop;
+  napi_get_uv_event_loop(env, &event_loop);
+  push_callback = new uv_async_t;
+  uv_async_init(event_loop, push_callback, &ReadableCustomIO::PushPendingData);
+  push_callback->data = this;
 }
 
 ReadableCustomIO::~ReadableCustomIO() {
-  verbose("ReadableCustomIO: destroy, queue elements %lu, queue_size %lu\n", queue.size(), queue_size);
   std::unique_lock lk{lock};
+  push_callback->data = nullptr;
+  uv_close(reinterpret_cast<uv_handle_t *>(push_callback),
+           [](uv_handle_t *async) { delete (reinterpret_cast<uv_async_t *>(async)); });
+  assert(!flowing);
   while (!queue.empty()) {
-    delete queue.front();
+    auto buf = queue.front();
     queue.pop();
+    if (buf->data != nullptr)
+      delete[] buf->data;
+    delete buf;
   }
+  verbose("ReadableCustomIO %p: destroy\n", this);
 }
 
 void ReadableCustomIO::Init(const Napi::CallbackInfo &info) {
@@ -58,7 +72,7 @@ int ReadableCustomIO::write(const uint8_t *data, size_t size) {
   queue.push(buffer);
   queue_size += size;
   lk.unlock();
-  cv.notify_one();
+  uv_async_send(push_callback);
 
   return size;
 }
@@ -73,28 +87,48 @@ int64_t ReadableCustomIO::seek(int64_t offset, int whence) {
 }
 int ReadableCustomIO::seekable() const { return 0; }
 
-// Called only when we know that the queue is not empty
-// with the lock already held
-void ReadableCustomIO::PushPendingData(int64_t to_read) {
-  verbose("ReadableCustomIO: push pending data: request %lu bytes\n", to_read);
-  Napi::Env env(Env());
-  Napi::Function push = Value().Get("push").As<Napi::Function>();
-  assert(!queue.empty());
+void ReadableCustomIO::PushPendingData(uv_async_t *async) {
+  ReadableCustomIO *self = reinterpret_cast<ReadableCustomIO *>(async->data);
+  assert(self != nullptr);
+  Napi::Env env{self->Env()};
+  Napi::HandleScope scope{env};
+
+  verbose("ReadableCustomIO %p: push pending data\n", self);
+  Napi::Function push = self->Value().Get("push").As<Napi::Function>();
+  Napi::Value more;
+  std::unique_lock lk{self->lock};
+  if (!self->flowing) {
+    verbose("ReadableCustomIO: not flowing\n");
+    return;
+  }
+  if (self->queue.empty()) {
+    verbose("ReadableCustomIO: queue is empty\n");
+    return;
+  }
   do {
-    auto buf = queue.front();
-    queue.pop();
+    auto buf = self->queue.front();
+    self->queue.pop();
+    self->queue_size -= buf->length;
     if (buf->data == nullptr) {
       // This is EOF
       verbose("ReadableCustomIO: pushing null to signal EOF\n");
-      push.MakeCallback(Value(), {env.Null()});
+      lk.unlock();
+      push.MakeCallback(self->Value(), {env.Null()});
+      lk.lock();
       delete buf;
-      eof = true;
-      if (!final_callback.IsEmpty()) {
-        final_callback.MakeCallback(Value(), 0, nullptr);
+      self->eof = true;
+      if (!self->final_callback.IsEmpty()) {
+        lk.unlock();
+        self->final_callback.MakeCallback(self->Value(), 0, nullptr, self->async_context);
+        lk.lock();
+      }
+      if (self->flowing) {
+        verbose("ReadableCustomIO: EOF, stop flowing\n");
+        self->flowing = false;
+        self->Unref();
       }
       return;
     }
-    to_read -= buf->length;
     // Some alternative Node-API implementations (Electron for example) disallow external buffers
 #ifdef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
     napi_value js_buffer = Napi::Buffer<uint8_t>::Copy(env, buf->data, buf->length);
@@ -103,60 +137,43 @@ void ReadableCustomIO::PushPendingData(int64_t to_read) {
     napi_value js_buffer =
         Napi::Buffer<uint8_t>::New(env, buf->data, buf->length, [](Napi::Env, uint8_t *buffer) { delete[] buffer; });
 #endif
-    verbose("ReadableCustomIO: pushed Buffer length %lu, request remaining %ld\n", buf->length, to_read);
-    push.MakeCallback(Value(), 1, &js_buffer);
-    queue_size -= buf->length;
+    verbose("ReadableCustomIO: pushed Buffer length %lu\n", buf->length);
+    // MakeCallBack runs the microtasks queue, this means that everything
+    // in this class must be reentrable as this will potentially call another _read
+    lk.unlock();
+    more = push.MakeCallback(self->Value(), 1, &js_buffer, self->async_context);
+    lk.lock();
     delete buf;
-  } while (!queue.empty() && to_read > 0);
+  } while (!self->queue.empty() && more.ToBoolean().Value());
+  if (more.ToBoolean().Value() == false) {
+    verbose("ReadableCustomIO: pipe is full, stop flowing\n");
+    self->flowing = false;
+    self->Unref();
+  }
+  lk.unlock();
+  // Unblock write if it is waiting because it has reached the high water mark
+  self->cv.notify_one();
 }
 
 void ReadableCustomIO::_Read(const Napi::CallbackInfo &info) {
-  // When it is called without any pending data,
-  // _read is an async operation and uses a worker
-  class AsyncReader : public Napi::AsyncWorker {
-    ReadableCustomIO &self;
-    int64_t to_read;
-
-  public:
-    AsyncReader(Napi::Env env, ReadableCustomIO &io, int64_t size)
-        : Napi::AsyncWorker(env, "ffmpeg_Readable_IO"), self(io), to_read(size) {}
-    void Execute() override {
-      // Wait for data in a background thread
-      verbose("ReadableCustomIO: waiting for data in a background thread\n");
-      std::unique_lock lk{self.lock};
-      self.cv.wait(lk, [this] { return !self.queue.empty(); });
-      verbose("ReadableCustomIO: data is available\n");
-    }
-    void OnOK() override {
-      verbose("ReadableCustomIO: will push pending data\n");
-      std::unique_lock lk{self.lock};
-      self.PushPendingData(to_read);
-      lk.unlock();
-      self.cv.notify_one();
-    }
-  };
-
-  verbose("ReadableCustomIO: JS is reading\n");
   Napi::Env env{info.Env()};
 
   if (!info[0].IsNumber())
     throw Napi::Error::New(env, "_read did not receive a size");
 
-  int64_t to_read = info[0].ToNumber().Int64Value();
-  verbose("ReadableCustomIO: reading %lu bytes, queue_size is %lu\n", to_read, queue_size);
+  verbose("ReadableCustomIO %p: JS is reading, queue_size is %lu\n", this, queue_size);
 
-  std::unique_lock lk{lock};
   if (eof)
     throw Napi::Error::New(env, "_read past EOF");
-  if (queue.empty()) {
-    // No pending data, return immediately and launch a read in a background thread
-    (new AsyncReader(env, *this, to_read))->Queue();
-  } else {
-    // Pending data, send immediately
-    PushPendingData(to_read);
-    lk.unlock();
-    cv.notify_one();
+  if (flowing) {
+    verbose("ReadableCustomIO: already reading\n");
+    return;
   }
+
+  verbose("ReadableCustomIO: start flowing\n");
+  flowing = true;
+  Ref();
+  uv_async_send(push_callback);
 }
 
 void ReadableCustomIO::_Final(const Napi::CallbackInfo &info) {
@@ -170,6 +187,5 @@ void ReadableCustomIO::_Final(const Napi::CallbackInfo &info) {
 
   std::unique_lock lk{lock};
   queue.push(buffer);
-  lk.unlock();
-  cv.notify_one();
+  uv_async_send(push_callback);
 }

--- a/src/lib/Muxer.ts
+++ b/src/lib/Muxer.ts
@@ -173,13 +173,17 @@ export class Muxer extends EventEmitter {
     this.destroyed = true;
     verbose(`Muxer: destroy: ${e}`);
     await this.formatContext.closeAsync();
+    const finalize = () => {
+      for (const s in this.streams) {
+        this.streams[s].destroy(e);
+      }
+      this.emit('error', e);
+    };
     if (this.output) {
-      (this.output as any)._final();
+      (this.output as any)._final(finalize);
+    } else {
+      finalize();
     }
-    for (const s in this.streams) {
-      this.streams[s].destroy(e);
-    }
-    this.emit('error', e);
   }
 
   protected async prime(): Promise<void> {

--- a/src/lib/Muxer.ts
+++ b/src/lib/Muxer.ts
@@ -172,13 +172,13 @@ export class Muxer extends EventEmitter {
     if (this.destroyed) return;
     this.destroyed = true;
     verbose(`Muxer: destroy: ${e}`);
+    await this.formatContext.closeAsync();
     if (this.output) {
       (this.output as any)._final();
     }
     for (const s in this.streams) {
       this.streams[s].destroy(e);
     }
-    await this.formatContext.closeAsync();
     this.emit('error', e);
   }
 

--- a/src/lib/Muxer.ts
+++ b/src/lib/Muxer.ts
@@ -177,13 +177,13 @@ export class Muxer extends EventEmitter {
       for (const s in this.streams) {
         this.streams[s].destroy(e);
       }
-      this.emit('error', e);
     };
     if (this.output) {
       (this.output as any)._final(finalize);
     } else {
       finalize();
     }
+    this.emit('error', e);
   }
 
   protected async prime(): Promise<void> {

--- a/src/lib/Muxer.ts
+++ b/src/lib/Muxer.ts
@@ -242,6 +242,9 @@ export class Muxer extends EventEmitter {
       callback();
       return;
     }
+    if (this.delayedDestroy) {
+      return void callback(this.delayedDestroy);
+    }
 
     this.writingQueue.push({ idx, packet, callback });
     if (this.writing) {
@@ -269,6 +272,7 @@ export class Muxer extends EventEmitter {
           if (this.delayedDestroy) {
             verbose('Muxer: destroyed while writing, resuming destroy');
             this.writing = false;
+            this.writingQueue = [];
             return void job.callback(this.delayedDestroy);
           }
           job.callback();

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -204,6 +204,7 @@ describe('streaming', () => {
   it('error handling on creation', (done) => {
     // MP4 does not support streaming in its default configuration
     const demuxer = new Demuxer({ inputFile: path.resolve(__dirname, 'data', 'launch.mp4') });
+    const output = fs.createWriteStream(tempFile);
 
     demuxer.on('error', done);
     demuxer.on('ready', () => {
@@ -243,6 +244,7 @@ describe('streaming', () => {
         muxer.on('error', (e) => {
           try {
             assert.match(e.message, /Invalid argument/);
+            output.close();
             done();
           } catch (e) {
             done(e);
@@ -250,7 +252,6 @@ describe('streaming', () => {
         });
 
         assert.instanceOf(muxer.output, Readable);
-        const output = fs.createWriteStream(tempFile);
 
         demuxer.video[0].pipe(videoInput).pipe(videoOutput).pipe(muxer.video[0]);
         demuxer.audio[0].pipe(audioInput).pipe(audioOutput).pipe(muxer.audio[0]);


### PR DESCRIPTION
Do not use an `Napi::AsyncWorker`, push data when ffmpeg writes

* do not eat a background thread slot only to wait on a lock
* less prone to deadlocks especially when handling errors
* better flow control