### PR TITLE
Revert "Bump node-addon-api from 8.1.0 to 8.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3321,9 +3321,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.2.0.tgz",
-      "integrity": "sha512-qnyuI2ROiCkye42n9Tj5aX1ns7rzj6n7zW1XReSnLSL9v/vbLeR6fJq6PU27YU/ICfYw6W7Ouk/N7cysWu/hlw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
+      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }


### PR DESCRIPTION
Reverts mmomtchev/ffmpeg#176

Node, wake up, summer is over, this is the nominal code path, it is not even on the exception path, if there are changes to how this must be used, say it and use a major version